### PR TITLE
Use shadowenv parent links instead of traversing the entire file tree

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -79,8 +79,8 @@ Make sure to restart your shell after adding this.
 
 # A Quick Demo
 
-Shadowenv constantly scans your current directory and all of its parents for directories named
-`.shadowenv.d`. It applies environments from all ancestors of the current directory, in order from highest to lowest in the file system tree (closest environment is applied last).
+Shadowenv constantly scans your current directory and all of its parents for a directory named
+`.shadowenv.d`, which is called your closest shadowenv. Shadowenv environments can stack by linking to each other using a `parent` symlink (`.shadowenv.d/parent`). Shadowenv will collect and apply all linked environments from the closest shadowenv in order from highest to lowest in the file system tree (closest environment is applied last).
 
 When `.shadowenv.d` directories are found, Shadowenv first checks that you've [Trusted]({% if jekyll.environment == 'production' %}{{ site.doks.baseurl }}{% endif %}/trust) them.
 Then, it looks for any files ending with `.lisp` in those directories, and runs them as
@@ -102,8 +102,7 @@ shadowenv trust
 ```
 
 This will mark the closest shadowenv directory as trusted, telling shadowenv that it can safely run any shadowlisp
-programs it finds inside. You should see an activation message in your terminal, which now includes information about added and removed directories. Then, if you `echo
-$DEBUG`, you will see "1" printed, because the script set "DEBUG" to "1".
+programs it finds inside. Note: To trust other shadowenvs further up, you'll need to `cd` up the tree and run `shadowenv trust` there. You should see an activation message in your terminal, which now includes information about added and removed directories. Then, if you `echo $DEBUG`, you will see "1" printed, because the script set "DEBUG" to "1".
 
 Next, `cd ..` to get out of the directory containing the shadowenv. You will see a deactivation message printed automatically, also showing which directories were removed. If you `echo $DEBUG`, you'll see whatever value you had prior to
 activating the Shadowenv: most likely no value.

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -241,6 +241,14 @@ mod tests {
         // Create test directories and files
         fs::create_dir_all(base_path.join("dir1/.shadowenv.d")).unwrap();
         fs::create_dir_all(base_path.join("dir1/dir2/.shadowenv.d")).unwrap();
+
+        // Link the two shadowenvs.
+        std::os::unix::fs::symlink(
+            base_path.join("dir1/.shadowenv.d"),
+            base_path.join("dir1/dir2/.shadowenv.d/parent"),
+        )
+        .unwrap();
+
         fs::write(
             base_path.join("dir1/.shadowenv.d/test.lisp"),
             "(env/set \"ORDER\" \"1\")",

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -116,7 +116,7 @@ fn load_trusted_sources(
     #[cfg(not(test))]
     assert!(!skip_trust_check);
 
-    let roots = loader::find_roots(&pathbuf, loader::DEFAULT_RELATIVE_COMPONENT)?;
+    let roots = loader::find_shadowenv_paths(&pathbuf)?;
     if roots.is_empty() {
         return Ok(None);
     }

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,12 +1,43 @@
 use crate::hash::Source;
 use anyhow::Error;
 use std::{
-    fs,
-    io::ErrorKind,
+    borrow::Cow,
+    fs, iter,
     path::{Path, PathBuf},
 };
 
-pub const SHADOWENV_DIR: &str = ".shadowenv.d";
+pub const SHADOWENV_DIR_NAME: &str = ".shadowenv.d";
+pub const SHADOWENV_PARENT_LINK_NAME: &str = "parent";
+
+#[derive(thiserror::Error, Debug)]
+enum TraversalError {
+    #[error("Error for parent file at {}: {}", parent_link_path, error)]
+    ResolveError {
+        parent_link_path: String,
+        error: String,
+    },
+
+    #[error(
+        "Parent symlink at {} must link to a {} directory, but links to {}",
+        path_to_parent_link,
+        SHADOWENV_DIR_NAME,
+        parent_link_target
+    )]
+    InvalidLinkTarget {
+        path_to_parent_link: String,
+        parent_link_target: String,
+    },
+
+    #[error(
+        "Parent symlink {} must be an ancestor of {}",
+        parent_link_target,
+        shadowenv_path
+    )]
+    NotAnAncestor {
+        parent_link_target: String,
+        shadowenv_path: String,
+    },
+}
 
 /// Search upwards the filesystem starting at `at` to find the closest shadowenv,
 /// then traverse any parent symlinks if they exist (.shadowenv.d/parent).
@@ -19,18 +50,82 @@ pub const SHADOWENV_DIR: &str = ".shadowenv.d";
 /// This call does _not_ verify that any of the found shadowenvs is trusted.
 /// See [crate::trust::ensure_dir_tree_trusted] for checking trust.
 pub fn find_shadowenv_paths(at: &Path) -> Result<Vec<PathBuf>, Error> {
-    let mut roots = Vec::new();
+    // First find the closest shadowenv.
+    let closest = match closest_shadowenv(at)? {
+        Some(closest) => closest,
+        None => return Ok(vec![]),
+    };
 
-    for curr in at.ancestors() {
-        let dirpath = curr.join(SHADOWENV_DIR);
+    // Then find all parents recursively. Any validation errors bubble up.
+    let parents = resolve_shadowenv_parents(&closest)?;
 
-        match fs::read_dir(&dirpath) {
-            Ok(_) => roots.push(fs::canonicalize(dirpath)?),
-            Err(ref e) if e.kind() == ErrorKind::NotFound => (),
-            Err(e) => return Err(e.into()),
+    Ok(iter::once(closest).chain(parents).collect())
+}
+
+fn closest_shadowenv(at: &Path) -> Result<Option<PathBuf>, Error> {
+    for ancestor in at.ancestors() {
+        let dirpath = ancestor.join(SHADOWENV_DIR_NAME);
+        let metadata = match fs::metadata(&dirpath) {
+            Ok(metadata) => metadata,
+            Err(_) => continue, // Doens't exist or lacking permissions.
+        };
+
+        if metadata.is_dir() {
+            return Ok(Some(fs::canonicalize(dirpath)?));
         }
     }
-    Ok(roots)
+
+    Ok(None)
+}
+
+/// Recursively resolves parents.
+/// Expects `from_shadowenv` to be canonicalized.
+fn resolve_shadowenv_parents(from_shadowenv: &PathBuf) -> Result<Vec<PathBuf>, TraversalError> {
+    let parent_link = from_shadowenv.join(SHADOWENV_PARENT_LINK_NAME);
+    if let Err(_) = fs::metadata(&parent_link) {
+        // Symlink doesn't exist or process is lacking permissions.
+        return Ok(vec![]);
+    };
+
+    // if !metadata.is_symlink() {
+    //     return Err(TraversalError::NotASymlink(
+    //         parent_pointer.to_string_lossy().to_string(),
+    //     ));
+    // }
+
+    // Must be a valid symlink.
+    let resolved_parent = fs::read_link(&parent_link)
+        .and_then(|resolved| resolved.canonicalize())
+        .map_err(|err| TraversalError::ResolveError {
+            parent_link_path: parent_link.to_string_lossy().to_string(),
+            error: err.to_string(),
+        })?;
+
+    // TODO: Refactor into better structure with the options.
+    let base_name = resolved_parent.file_name();
+    let base_name_stringified = base_name.map(|f| f.to_string_lossy());
+
+    // Must point to a SHADOWENV_DIR_NAME (e.g. `.shadowenv.d`).
+    if base_name_stringified != Some(Cow::Borrowed(SHADOWENV_DIR_NAME)) {
+        return Err(TraversalError::InvalidLinkTarget {
+            path_to_parent_link: parent_link.to_string_lossy().to_string(),
+            parent_link_target: base_name_stringified.unwrap().to_string(),
+        });
+    }
+
+    // Must be an ancestor of the shadowenv we're coming from.
+    // Unwrap is safe, we're always resolving to at least SHADOWENV_DIR_NAME.
+    if !from_shadowenv.starts_with(&resolved_parent.parent().unwrap()) {
+        return Err(TraversalError::NotAnAncestor {
+            parent_link_target: resolved_parent.to_string_lossy().to_string(),
+            shadowenv_path: from_shadowenv.to_string_lossy().to_string(),
+        });
+    }
+
+    // Find parents of parent.
+    let parents = resolve_shadowenv_parents(&resolved_parent)?;
+
+    Ok(iter::once(resolved_parent).chain(parents).collect())
 }
 
 /// Load all .lisp files in the directory pointed by `dirpath` storing their names and contents as

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -53,6 +53,8 @@ pub enum TraversalError {
 /// - Each parent must be an ancestor of the previous parent. Parent links can't
 ///   therefore point to adjacent or sub folders.
 /// - Each parent must point to a `.shadowenv.d` basename folder.
+/// - A shadowenv must not reference itself.
+/// - A shadowenv parent link must be a symlink link pointing to a `.shadowenv.d`.
 ///
 /// This call does _not_ verify that any of the found shadowenvs is trusted.
 /// See [crate::trust::ensure_dir_tree_trusted] for checking trust.

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -130,7 +130,7 @@ fn resolve_shadowenv_parents(from_shadowenv: &PathBuf) -> Result<Vec<PathBuf>, T
     let base_name_stringified = base_name.map(|f| f.to_string_lossy());
 
     // Must point to a SHADOWENV_DIR_NAME (e.g. `.shadowenv.d`).
-    if base_name_stringified != Some(Cow::Borrowed(SHADOWENV_DIR_NAME)) {
+    if base_name_stringified.as_deref() != Some(SHADOWENV_DIR_NAME) {
         return Err(TraversalError::InvalidLinkTarget {
             path_to_parent_link: parent_link.to_string_lossy().to_string(),
             parent_link_target: base_name_stringified.unwrap().to_string(),
@@ -146,7 +146,7 @@ fn resolve_shadowenv_parents(from_shadowenv: &PathBuf) -> Result<Vec<PathBuf>, T
 
     // Must be an ancestor of the shadowenv we're coming from.
     // Unwrap is safe, we're always resolving to at least SHADOWENV_DIR_NAME.
-    if !from_shadowenv.starts_with(&resolved_parent.parent().unwrap()) {
+    if !from_shadowenv.starts_with(resolved_parent.parent().unwrap()) {
         return Err(TraversalError::NotAnAncestor {
             parent_link_target: resolved_parent.to_string_lossy().to_string(),
             shadowenv_path: from_shadowenv.to_string_lossy().to_string(),

--- a/src/output.rs
+++ b/src/output.rs
@@ -115,7 +115,7 @@ fn backticks_to_bright_green(err: Error) -> String {
 
 fn check_and_trigger_cooldown(err: &Error, shellpid: u32) -> Result<bool, Error> {
     // if no .shadowenv.d, then Err(_) just means no cooldown: always display error.
-    let roots = loader::find_roots(&env::current_dir()?, loader::DEFAULT_RELATIVE_COMPONENT)?;
+    let roots = loader::find_shadowenv_paths(&env::current_dir()?)?;
     if roots.is_empty() {
         return Err(anyhow!("no .shadowenv.d"));
     }

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -112,7 +112,7 @@ fn load_or_generate_signer() -> Result<SigningKey, Error> {
 pub fn run(dir: PathBuf) -> Result<(), Error> {
     let signer = load_or_generate_signer().unwrap();
 
-    let roots = loader::find_roots(&dir, loader::DEFAULT_RELATIVE_COMPONENT)?;
+    let roots = loader::find_shadowenv_paths(&dir)?;
     if roots.is_empty() {
         return Err(NoShadowenv {}.into());
     }


### PR DESCRIPTION
Note: This PR is for reviewing, it depends on the PR opened upstream [here](https://github.com/Shopify/shadowenv/pull/118). If the other PR changes are accepted, I will reopen the PR upstream for final merging.

Example tree:
```
/example
├── .shadowenv.d
├── a
│   ├── .shadowenv.d
│   │       └── parent (/example/.shadowenv.d)
│   └── c
│       └── .shadowenv.d
│           └── parent (../../.shadowenv.d)
└── b
    └── .shadowenv.d
```

`example` <- `a` <- `c` form a hierarchy throught their `parent` links. However, `b` stands alone.
*Note that `c/.shadowenv.d/parent` resolves the relative path from inside `c/.shadowenv.d`.*
Links can skip any amount of levels, ie. c having `example` root as a parent is perfectly valid.

Let's say everything is untrusted, then being in `c` prints:
```
shadowenv failure: The following directories contain untrusted shadowenv programs (see shadowenv help trust to learn more):
/example/a/c/.shadowenv.d
/example/.shadowenv.d
```
`shadowenv trust`: will trust `/example/a/c/.shadowenv.d`.


Being in `b` prints:
```
shadowenv failure: directory: '/example/b/.shadowenv.d' contains untrusted shadowenv program: shadowenv help trust to learn more.
```

`shadowenv trust`: will trust `/example/b/.shadowenv.d`.

# Error modes
Parent is not a symlink:
```
shadowenv failure: Error for parent file at /example/a/c/.shadowenv.d/parent: Not a symlink
```

Parent linked to doesn't exist:
```
shadowenv failure: Error for parent file at /example/a/c/.shadowenv.d/parent: No such file or directory (os error 2)
```

Shadowenv references itself as parent:
```
shadowenv failure: Shadow env at /Users/dom/Documents/shadowenv-example/a/c/.shadowenv.d references itself
```

Shadowenv parent is not an ancestor:
```
shadowenv failure: Parent symlink /example/b/.shadowenv.d must be an ancestor of /example/a/.shadowenv.d
```

Shadowenv parent linked is not a `.shadowenv.d`:
```
shadowenv failure: Parent symlink at /example/a/.shadowenv.d/parent must link to a .shadowenv.d directory, but links to not-a-shadowenv.
```